### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run test"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 [![npm version](https://badge.fury.io/js/replitdb-client.svg)](https://badge.fury.io/js/replitdb-client)
+
+[![Run on Repl.it](https://repl.it/badge/github/mrlapizgithub/repl.it-db)](https://repl.it/github/mrlapizgithub/repl.it-db)
+
 # Repl.it DB Client
 Repl.it-db client is a simple way to use the repl.it database. It uses `await/async`.
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).