### PR TITLE
Update export in declarations file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export class Client {
+export default class Client {
   constructor(key?: string);
 
   // Native


### PR DESCRIPTION
When trying to import the Client by doing `import Client from '@repl/database'` in Typescript, an error is generated stating that the expression is not constructable:


```
This expression is not constructable.
  Type 'typeof import' has no construct signatures 
```

This seems to happen because while the client is a "default export", the declaration is not. Adding default to the declarations file seems to fix the problem