### PR TITLE
encode uri for deleting keys

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,4 +18,4 @@ blocks:
             - npm run build --if-present
             - npm test
       secrets:
-        - name: Repl.it Database
+        - name: replit-database

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Repl.it Database client is a simple way to use Repl.it Database in your Node.js 
 ```js
 const Client = require("@replit/database");
 const client = new Client();
-await Client.set("key", "value");
-let key = await Client.get("key");
+await client.set("key", "value");
+let key = await client.get("key");
 console.log(key);
 ```
 
@@ -26,7 +26,7 @@ These functions are specified in the repl.it DB.
 
 Gets a key. Returns Promise.
 ```js
-Client.get("key", { raw: false }).then(console.log);
+client.get("key", { raw: false }).then(console.log);
 ```
 
 > `set(String key, Any value)`

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class Client {
     await fetch(this.key, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: key + "=" + strValue,
+      body: encodeURIComponent(key) + "=" + encodeURIComponent(strValue),
     });
     return this;
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const fetch = require("node-fetch");
+const fetch = require('node-fetch');
 
 class Client {
   /**
@@ -17,7 +17,7 @@ class Client {
    * @param {boolean} [options.raw=false] Makes it so that we return the raw string value. Default is false.
    */
   async get(key, options) {
-    return await fetch(this.key + "/" + key)
+    return await fetch(this.key + '/' + key)
       .then((e) => e.text())
       .then((strValue) => {
         if (options && options.raw) {
@@ -55,9 +55,9 @@ class Client {
     const strValue = JSON.stringify(value);
 
     await fetch(this.key, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: encodeURIComponent(key) + "=" + encodeURIComponent(strValue),
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: encodeURIComponent(key) + '=' + encodeURIComponent(strValue),
     });
     return this;
   }
@@ -67,7 +67,7 @@ class Client {
    * @param {String} key Key
    */
   async delete(key) {
-    await fetch(this.key + "/" + key, { method: "DELETE" });
+    await fetch(this.key + '/' + encodeURIComponent(key), { method: 'DELETE' });
     return this;
   }
 
@@ -75,7 +75,7 @@ class Client {
    * List key starting with a prefix or list all.
    * @param {String} prefix Filter keys starting with prefix.
    */
-  async list(prefix = "") {
+  async list(prefix = '') {
     return await fetch(
       this.key + `?encode=true&prefix=${encodeURIComponent(prefix)}`
     )
@@ -84,7 +84,7 @@ class Client {
         if (t.length === 0) {
           return [];
         }
-        return t.split("\n").map(decodeURIComponent);
+        return t.split('\n').map(decodeURIComponent);
       });
   }
 

--- a/index.test.js
+++ b/index.test.js
@@ -73,3 +73,9 @@ test("list keys with newline", async () => {
 
   expect(await client.list()).toEqual(["keywidout", "key\nwit"]);
 });
+
+test("ensure that we escape values when setting", async () => {
+  expect(await client.set("a", "1;b=2")).toEqual(client);
+  expect(await client.list()).toEqual(["a"])
+  expect(await client.get("a")).toEqual("1;b=2")
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/database",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/database",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/database",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Client for Repl.it Database",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/database",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Client for Repl.it Database",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Database keys are converted to URI components before storing. When we delete a key, we aren't first encoding it to a URI component which is why it's impossible to empty a database if a key has invalid chars such as a URL.